### PR TITLE
Minor fix: Remove additional previousAnswers[] cell that is not used.

### DIFF
--- a/Dynamic Programming, Recursion, & Backtracking/decodeWays.java
+++ b/Dynamic Programming, Recursion, & Backtracking/decodeWays.java
@@ -18,7 +18,7 @@ public int numDecodings(String s) {
   /*
     We will cache the answers to our subproblems
   */
-  int[] previousAnswers = new int[s.length() + 1];
+  int[] previousAnswers = new int[s.length()];
   Arrays.fill(previousAnswers, -1);
 
   return numDecodings(s, 0, previousAnswers);


### PR DESCRIPTION
- Tested and verified on Leetcode.
- Won't make change to the behavior of the original code but it will improve readability.
- Final result computed is at `previousAnswers[0]`
