### PR TITLE
Fix heap's hasParent method returning true for the root element

### DIFF
--- a/Sorting, Searching, & Heaps/ImplementABinaryHeap/ImplementABinaryHeap.java
+++ b/Sorting, Searching, & Heaps/ImplementABinaryHeap/ImplementABinaryHeap.java
@@ -20,7 +20,7 @@
 */
 import java.util.*;
 
-public class ImplementAMinHeap {
+public class ImplementABinaryHeap {
   public static void main(String args[]) {
     MinHeap minHeap = new MinHeap();
     int[] insertItems = new int[]{ 0, 1, 3, 2, -4, 9, 1, 2 };
@@ -218,7 +218,7 @@ public class ImplementAMinHeap {
     }
 
     private boolean hasParent(int index) {
-      return getParentIndex(index) >= 0;
+      return index != 0 && getParentIndex(index) >= 0;
     }
 
     private int leftChild(int index) {


### PR DESCRIPTION
I found a small inconsistency in code. In video explanation, you say that the root element has no parent, but it is not reflected in the code of `hasParent` method because `getParentIndex` returns 0 for index 0 (why? -> `(0 - 1) / 2 = 0`).
This bug doesn't affect the correctness of the `siftUp` method as `heap[index] < parent(index)` results in `false` because the root element is equal to itself, it is not less. But I think that implementation should follow the description precisely. Moreover, it seems that the whole point of using `hasParent` in the `while` statement of the `siftUp` method is to terminate at the root element.
Other solutions to this might be returning -1 from `getParentIndex` or getting rid of `hasParent` entirely, but I choose this one.

Another thing is that I had to rename class from `ImplementAMinHeap` to `ImplementABinaryHeap`, as in java, it is a requirement that if the class is public, then its name must be equal to the name of the file where it is located. I could have renamed the file, but then the links from the course would become broken.